### PR TITLE
Sanitize IDs when fetched from options

### DIFF
--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -85,7 +85,7 @@ class Hidden_Posts {
      * Get the array of posts
      */
     static function get_posts() {
-        return get_option( self::META_KEY, array() );
+        return array_filter( array_map( 'absint', get_option( self::META_KEY, array() ) ) );
     }
 
     /**


### PR DESCRIPTION
Who knows what nasty things are hiding there? absint and array_filter to
get rid of any bad stuff.
