### PR TITLE
👌 IMPROVE: Update "Requires at least" and "Tested up to"

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Hidden Posts ===
 Contributors: automattic, betzster, batmoo
 Tags: posts
-Requires at least: 3.8
-Tested up to: 3.8
+Requires at least: 2.9
+Tested up to: 4.9
 Stable tag: 0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Closes #13 

**Change**

Update WordPress version numbers for `Requires at least` and `Tested up to`.

**Steps to test**

1. Install [WP Downgrade | Specific Core Version](https://wordpress.org/plugins/wp-downgrade/) plugin
2. Downgrade core to 4.9.16, the latest version before Gutenberg was bundled
3. Check that the `Hide Post` checkbox is visible in the publish section on the post edit page
4. Downgrade core to 2.9, the version in which the action [`post_submitbox_misc_actions`](https://developer.wordpress.org/reference/hooks/post_submitbox_misc_actions/) was added
5. Check that the `Hide Post` checkbox is still visible
6. Downgrade core to 2.8, the version before the action [`post_submitbox_misc_actions`](https://developer.wordpress.org/reference/hooks/post_submitbox_misc_actions/) was added
7. Check that the `Hide Post` checkbox is no longer visible

**Note**

The `Tested up to` cannot be bumped to 5.7, as the plugin does not support Gutenberg currently. Issue #10 had been created for that, and I'm already working on an update.



