### PR TITLE
📦 NEW: Indicate visibility status in admin columns

### DIFF
--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -156,7 +156,7 @@ class Hidden_Posts {
     public function custom_column_data( string $column, int $post_id ) {
         if ( 'visibility' === $column ) {
             $post_ids = Hidden_Posts::get_posts();
-            echo in_array( $post_id, $post_ids ) ?
+            echo in_array( $post_id, $post_ids, true ) ?
                 '<span class="dashicons dashicons-hidden"></span>' :
                 '<span class="dashicons dashicons-visibility"></span>';
         }

--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -32,6 +32,11 @@ class Hidden_Posts {
         add_action( 'post_submitbox_misc_actions', array( $this, 'hidden_checkbox' ) );
         add_action( 'save_post', array( $this, 'save_meta' ) );
         add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
+        add_filter( 'manage_pages_columns', array( $this, 'custom_column_title' ) );
+        add_filter( 'manage_pages_custom_column', array( $this, 'custom_column_data'), 10, 2 );
+        add_filter( 'manage_posts_columns', array( $this, 'custom_column_title' ) );
+        add_filter( 'manage_posts_custom_column', array( $this, 'custom_column_data'), 10, 2 );
+        add_action( 'admin_head', array( $this, 'custom_column_style' ) );
     }
 
     /**
@@ -126,6 +131,44 @@ class Hidden_Posts {
         array_splice( $posts, array_search( $id, $posts ), 1 );
 
         update_option( self::META_KEY, array_map( 'intval', $posts ) );
+    }
+
+    /**
+     * Add custom title to the admin columns.
+     *
+     * @param array $columns The original admin column titles.
+     * @return array The updated admin column titles.
+     */
+    public function custom_column_title( array $columns ): array {
+        unset($columns['date']);
+        $columns['visibility'] = esc_html__( 'Visibility' );
+        $columns['date'] = esc_html__( 'Date' );
+        return $columns;
+    }
+
+    /**
+     * Add custom data to the admin columns.
+     *
+     * @param string $column The column to which the data should be added.
+     * @param int $post_id The id of the post to which the data should be added.
+     * @return void The added data.
+     */
+    public function custom_column_data( string $column, int $post_id ) {
+        if ( 'visibility' === $column ) {
+            $post_ids = Hidden_Posts::get_posts();
+            echo in_array( $post_id, $post_ids ) ?
+                '<span class="dashicons dashicons-hidden"></span>' :
+                '<span class="dashicons dashicons-visibility"></span>';
+        }
+    }
+
+    /**
+     * Add custom styles to the admin columns.
+     *
+     * @return void The custom styles for the admin columns.
+     */
+    public function custom_column_style() {
+        print( '<style> .fixed .column-visibility { width: 5.5em; } </style>'  );
     }
 
 }

--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -168,7 +168,7 @@ class Hidden_Posts {
      * @return void The custom styles for the admin columns.
      */
     public function custom_column_style() {
-        print( '<style> .fixed .column-visibility { width: 5.5em; } </style>'  );
+        print( '<style> .fixed .column-visibility { width: 5.5em; } </style>' );
     }
 
 }

--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -32,8 +32,6 @@ class Hidden_Posts {
         add_action( 'post_submitbox_misc_actions', array( $this, 'hidden_checkbox' ) );
         add_action( 'save_post', array( $this, 'save_meta' ) );
         add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
-        add_filter( 'manage_pages_columns', array( $this, 'custom_column_title' ) );
-        add_filter( 'manage_pages_custom_column', array( $this, 'custom_column_data'), 10, 2 );
         add_filter( 'manage_posts_columns', array( $this, 'custom_column_title' ) );
         add_filter( 'manage_posts_custom_column', array( $this, 'custom_column_data'), 10, 2 );
         add_action( 'admin_head', array( $this, 'custom_column_style' ) );


### PR DESCRIPTION
Fixes #8 

**Change**

Indicate visibility status in admin columns.

**Steps to test**

1. Check out this PR
2. Go to `/wp-admin/edit.php`
3. Create one visible and one hidden post
4. Go to `/wp-admin/edit.php` and look up the visibility indicator

**Screenshots**

<table>
<tr>
<td>Posts - Before:
<br><br>

![#8-posts-before](https://user-images.githubusercontent.com/3323310/110954360-ff746900-837a-11eb-9af0-87d6c416fe37.png)
</td>
<td>Posts - After:
<br><br>

![#8-posts-after](https://user-images.githubusercontent.com/3323310/110954376-0307f000-837b-11eb-8a94-1efe67906d6a.png)
</td>
</tr>
</table>