### PR TITLE
👌 IMPROVE: Improve storage of visibility settings

### DIFF
--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -125,7 +125,7 @@ class Hidden_Posts {
         update_option( self::META_KEY, array_map( 'intval', $posts ) );
 
         // Delete post meta.
-				delete_post_meta( $id, self::META_KEY );
+        delete_post_meta( $id, self::META_KEY );
     }
 		
     /**

--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -122,8 +122,8 @@ class Hidden_Posts {
 
         update_option( self::META_KEY, array_map( 'intval', $posts ) );
 
-        // Update post meta.
-        update_post_meta( $id, self::META_KEY, 0 );
+        // Delete post meta.
+				delete_post_meta( $id, self::META_KEY );
     }
 
     /**

--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -27,8 +27,8 @@ class Hidden_Posts {
      * Maximum number of posts to store in the hidden array
      */
     const LIMIT = 100;
-		const VERSION = 1;
-		const VERSION_KEY = 'hidden_posts_version';
+    const VERSION = 1;
+    const VERSION_KEY = 'hidden_posts_version';
 
     function __construct() {
         add_action( 'save_post', array( $this, 'save_meta' ) );
@@ -128,31 +128,31 @@ class Hidden_Posts {
 				delete_post_meta( $id, self::META_KEY );
     }
 		
-		/**
-		 * Migrate IDs of hidden posts by duplicating them from wp_options to 
-		 * wp_postmeta in case the user is using an older version of the plugin.
-		 */
-		public function maybe_upgrade_version() {
-			$version = absint( get_option( self::VERSION_KEY, 0 ) );
+    /**
+     * Migrate IDs of hidden posts by duplicating them from wp_options to 
+     * wp_postmeta in case the user is using an older version of the plugin.
+     */
+    public function maybe_upgrade_version() {
+      $version = absint( get_option( self::VERSION_KEY, 0 ) );
 
-			if ( $version === self::VERSION ) {
-				return;
-			}
+      if ( $version === self::VERSION ) {
+        return;
+      }
 
-			$posts = self::get_posts();
+      $posts = self::get_posts();
 
-			if ( ! $posts ) {
-				return;
-			}
+      if ( ! $posts ) {
+        return;
+      }
 
-			foreach ( $posts as $post_id ) {
-				if ( get_post( $post_id ) ) {
-					update_post_meta( $post_id, self::META_KEY, 1 );
-				}
-			}
+      foreach ( $posts as $post_id ) {
+        if ( get_post( $post_id ) ) {
+          update_post_meta( $post_id, self::META_KEY, 1 );
+        }
+      }
 
-			update_option( self::VERSION_KEY, self::VERSION );
-		}
+      update_option( self::VERSION_KEY, self::VERSION );
+    }
 
     /**
      * Add custom title to the admin columns.

--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -32,6 +32,7 @@ class Hidden_Posts {
         add_action( 'post_submitbox_misc_actions', array( $this, 'hidden_checkbox' ) );
         add_action( 'save_post', array( $this, 'save_meta' ) );
         add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
+        add_action( 'upgrader_process_complete', array( $this, 'migrate_posts' ));
     }
 
     /**
@@ -109,6 +110,9 @@ class Hidden_Posts {
             array_shift( $posts );
 
         update_option( self::META_KEY, array_map( 'intval', $posts ) );
+
+        // Update post meta.
+        update_post_meta( $id, self::META_KEY, 1 );
     }
 
     /**
@@ -126,6 +130,21 @@ class Hidden_Posts {
         array_splice( $posts, array_search( $id, $posts ), 1 );
 
         update_option( self::META_KEY, array_map( 'intval', $posts ) );
+
+        // Update post meta.
+        update_post_meta( $id, self::META_KEY, 0 );
+    }
+
+    /**
+     * Migrate IDs of hidden posts by duplicating them from wp_options to wp_postmeta.
+     */
+    public function migrate_posts() {
+        $posts = self::get_posts();
+        foreach ( $posts as $post_id ) {
+            if ( get_post( $post_id ) ) {
+                update_post_meta( $post_id, self::META_KEY, 1 );
+            }
+        }
     }
 
 }

--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -136,7 +136,7 @@ class Hidden_Posts {
 			$version = absint( get_option( self::VERSION_KEY, 0 ) );
 
 			if ( $version === self::VERSION ) {
-        return;
+				return;
 			}
 
 			$posts = self::get_posts();
@@ -146,12 +146,12 @@ class Hidden_Posts {
 			}
 
 			foreach ( $posts as $post_id ) {
-        if ( get_post( $post_id ) ) {
-          update_post_meta( $post_id, self::META_KEY, 1 );
-        }
+				if ( get_post( $post_id ) ) {
+					update_post_meta( $post_id, self::META_KEY, 1 );
+				}
 			}
 
-      update_option( self::VERSION_KEY, self::VERSION );
+			update_option( self::VERSION_KEY, self::VERSION );
 		}
 
     /**

--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -27,6 +27,7 @@ class Hidden_Posts {
      * Maximum number of posts to store in the hidden array
      */
     const LIMIT = 100;
+    // Only bump version number when update script must be triggered.
     const VERSION = 1;
     const VERSION_KEY = 'hidden_posts_version';
 

--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -140,6 +140,8 @@ class Hidden_Posts {
         return;
       }
 
+      update_option( self::VERSION_KEY, self::VERSION );
+      
       $posts = self::get_posts();
 
       if ( ! $posts ) {
@@ -151,8 +153,6 @@ class Hidden_Posts {
           update_post_meta( $post_id, self::META_KEY, 1 );
         }
       }
-
-      update_option( self::VERSION_KEY, self::VERSION );
     }
 
     /**


### PR DESCRIPTION
Fixes #17 

**Change**

Store IDs of hidden posts not only in `wp_options` but also in `wp_postmeta` so that sorting and filtering of the visibility status in the admin columns can be implemented.

**Steps to test**

1. Check out this plugin
2. Look up the option `hidden-posts` in `wp_options`
3. Check that no rows for the key `hidden-posts` exist in `wp_postmeta`
4. Open the file hidden-posts.php
5. Change `add_action( 'upgrader_process_complete', array( $this, 'migrate_posts' ));` to `add_action( 'init', array( $this, 'migrate_posts' ));` to simulate a successful plugin update
3. Check that all IDs of hidden posts have been added as separate entries to `wp_postmeta`

**Note**

To ensure that all IDs of hidden posts get migrated from `wp_options` to `wp_postmeta`, I created a migration function, which will only be triggered when the plugin was successfully updated.