### PR TITLE
👌 IMPROVE: Remove `hidden_checkbox` from pages

### DIFF
--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -60,6 +60,10 @@ class Hidden_Posts {
     function hidden_checkbox() {
         global $post;
 
+        if ( 'post' !== $post->post_type ) {
+            return;
+        }
+
         $checked = in_array( $post->ID, self::get_posts() );
 
         wp_nonce_field( self::NONCE_KEY, self::NONCE_KEY );


### PR DESCRIPTION
Fixes #23 

**Change**

Remove the `hidden_checkbox` from the page editor, as pages are not listed on the homepage by default. Having the checkbox there, might lead to confusion as checking the checkbox will not change anything.

**Screenshots**

<table>
<tr>
<td>Before:
<br><br>

![#23-before](https://user-images.githubusercontent.com/3323310/111059075-5c7c3600-84c5-11eb-8846-f0ac8fbe0161.png)
</td>
<td>After:
<br><br>

![#23-after](https://user-images.githubusercontent.com/3323310/111059027-10c98c80-84c5-11eb-8091-de9ae2597b72.png)
</td>
</tr>
</table>

**Steps to test**

1. Check out this PR
2. Look up the page editor
3. The checkbox _Hide post_ is no longer visible