### PR TITLE
📦 NEW: Add Gutenberg compatibility

### DIFF
--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -29,8 +29,8 @@ class Hidden_Posts {
     const LIMIT = 100;
 
     function __construct() {
-        add_action( 'post_submitbox_misc_actions', array( $this, 'hidden_checkbox' ) );
         add_action( 'save_post', array( $this, 'save_meta' ) );
+        add_action( 'add_meta_boxes', array( $this, 'add_metabox'  ) );
         add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
     }
 
@@ -52,18 +52,6 @@ class Hidden_Posts {
 			$post_not_in = $hidden_posts;
 		}
 		$query->set( 'post__not_in', $post_not_in );
-    }
-
-    /**
-     * Show the checkbox in the admin
-     */
-    function hidden_checkbox() {
-        global $post;
-
-        $checked = in_array( $post->ID, self::get_posts() );
-
-        wp_nonce_field( self::NONCE_KEY, self::NONCE_KEY );
-        printf( '<div id="superawesome-box" class="misc-pub-section"><label><input type="checkbox" name="%s" %s> %s</label></div>', self::META_KEY, checked( $checked, true, false ), esc_html( apply_filters( 'hidden_posts_checkbox_text', 'Hide Post' ) ) );
     }
 
     /**
@@ -126,6 +114,36 @@ class Hidden_Posts {
         array_splice( $posts, array_search( $id, $posts ), 1 );
 
         update_option( self::META_KEY, array_map( 'intval', $posts ) );
+    }
+
+    /**
+     * Render the meta box for hiding a post.
+     */
+    public function add_metabox() {
+        add_meta_box(
+            'hidden-posts',
+            esc_html( apply_filters( 'hidden_posts_checkbox_title', 'Visibility' ) ),
+            array( $this, 'render_metabox' ),
+            'post',
+            'side',
+            'high'
+        );
+    }
+
+    /**
+     * Render the meta box for hiding a post.
+     *
+     * @param WP_Post $post The post object for which the metabox should be added.
+     */
+    public function render_metabox( WP_Post $post ) {
+        $checked = in_array( (int) $post->ID, self::get_posts(), true );
+        wp_nonce_field( self::NONCE_KEY, self::NONCE_KEY );
+        printf(
+            '<div id="superawesome-box" class="misc-pub-section"><label><input type="checkbox" name="%s" %s> %s</label></div>',
+            self::META_KEY,
+            checked( $checked, true, false ),
+            esc_html( apply_filters( 'hidden_posts_checkbox_text', 'Hide post' ) )
+        );
     }
 
 }


### PR DESCRIPTION
Fixes #10 

**Change**

Removed `hidden_checkbox` field and added metabox to show the visibility setting both in the classic and the block editor.

**Screenshots**

<table>
<tr>
<td>Before:
<br><br>

![#10-be-before](https://user-images.githubusercontent.com/3323310/111063440-0f0dc200-84e1-11eb-98b6-94c44e9347bc.png)
</td>
<td>After:
<br><br>

![#10-be-after](https://user-images.githubusercontent.com/3323310/111063442-0fa65880-84e1-11eb-9194-9c102acfcf5c.png)
</td>
</tr>
</table>

<table>
<tr>
<td>Before:
<br><br>

![#10-ce-before](https://user-images.githubusercontent.com/3323310/111063436-0ae1a480-84e1-11eb-9fc8-62c3bb9b805d.png)
</td>
<td>After:
<br><br>

![#10-ce-after](https://user-images.githubusercontent.com/3323310/111063444-103eef00-84e1-11eb-8a05-f949d3ecfe6e.png)
</td>
</tr>
</table>

**Steps to test**

1. Check out this PR
2. Install the [Classic Editor](https://wordpress.org/plugins/classic-editor/) plugin 
3. Create a new post using the block editor
4. The metabox _Visibility_ is visible and contains the checkbox _Hide post_
5. Check the checkbox and save the post
6. The checkbox is still checked
7. Activate the classic editor plugin
8. Create a separate post using the classic editor
9. The metabox _Visibility_  with the checkbox _Hide post_ is still visible
10. Check the checkbox and save the post
11. The checkbox is still checked