### PR TITLE
📦 NEW: Add filter to show hidden posts only

### DIFF
--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -22,9 +22,9 @@
  */
 class Hidden_Posts {
 
-	const META_KEY  = 'hidden-posts';
-	const NONCE_KEY = 'hidden-posts-nonce';
-	const LIMIT     = 100;
+	const OPTION_KEY = 'hidden-posts';
+	const NONCE_KEY  = 'hidden-posts-nonce';
+	const LIMIT      = 100;
 
 	/**
 	 * Constructor to call all needed functions.
@@ -80,7 +80,7 @@ class Hidden_Posts {
 		}
 
 		// Update the post array if necessary.
-		if ( isset( $_POST[ self::META_KEY ] ) ) {
+		if ( isset( $_POST[ self::OPTION_KEY ] ) ) {
 			self::add_post( $post );
 		} else {
 			self::remove_post( $post );
@@ -93,7 +93,7 @@ class Hidden_Posts {
 	 * @return array The array with the IDs of all hidden posts.
 	 */
 	public static function get_posts() {
-		return array_filter( array_map( 'absint', get_option( self::META_KEY, array() ) ) );
+		return array_filter( array_map( 'absint', get_option( self::OPTION_KEY, array() ) ) );
 	}
 
 	/**
@@ -120,7 +120,7 @@ class Hidden_Posts {
 			array_shift( $posts );
 		}
 
-		update_option( self::META_KEY, array_map( 'intval', $posts ) );
+		update_option( self::OPTION_KEY, array_map( 'intval', $posts ) );
 	}
 
 	/**
@@ -140,7 +140,7 @@ class Hidden_Posts {
 
 		array_splice( $posts, array_search( $id, $posts, true ), 1 );
 
-		update_option( self::META_KEY, array_map( 'intval', $posts ) );
+		update_option( self::OPTION_KEY, array_map( 'intval', $posts ) );
 	}
 
 	/**
@@ -198,14 +198,14 @@ class Hidden_Posts {
 			return $views;
 		}
 
-		if ( ! count( get_option( self::META_KEY, array() ) ) ) {
+		if ( ! count( get_option( self::OPTION_KEY, array() ) ) ) {
 			return $views;
 		}
 
 		global $wp_query;
 
 		$query           = array(
-			'post__in' => get_option( self::META_KEY, array() )
+			'post__in' => get_option( self::OPTION_KEY, array() ),
 		);
 		$result          = new WP_Query( $query );
 		$class           = ( isset( $_GET['show_hidden'] ) && '1' === $_GET['show_hidden'] ) ? 'class="current"' : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -248,7 +248,7 @@ class Hidden_Posts {
 		wp_nonce_field( self::NONCE_KEY, self::NONCE_KEY );
 		printf(
 			'<div id="superawesome-box" class="misc-pub-section"><label><input type="checkbox" name="%s" %s> %s</label></div>',
-			self::META_KEY, //phpcs:ignore
+			self::OPTION_KEY, //phpcs:ignore
 			checked( $checked, true, false ),
 			esc_html( apply_filters( 'hidden_posts_checkbox_text', 'Hide post' ) )
 		);

--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -66,7 +66,7 @@ class Hidden_Posts {
 	/**
 	 * Update the post array.
 	 *
-	 * @param int $post The post object that should be updated.
+	 * @param int $post The post ID that should be updated.
 	 */
 	public function save_meta( int $post ) {
 		// Bail if nonce if not available.

--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -210,8 +210,9 @@ class Hidden_Posts {
 		$result          = new WP_Query( $query );
 		$class           = ( isset( $_GET['show_hidden'] ) && '1' === $_GET['show_hidden'] ) ? 'class="current"' : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$views['hidden'] = sprintf(
-			'<a href="%s"' . $class . '>%s <span class="count">(%d)</span></a>',
+			'<a href="%s" %s>%s <span class="count">(%d)</span></a>',
 			admin_url( 'edit.php?post_type=post&show_hidden=1' ),
+			$class,
 			esc_html( apply_filters( 'hidden_posts_filter_title', 'Hidden' ) ),
 			$result->found_posts
 		);

--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -198,14 +198,14 @@ class Hidden_Posts {
 			return $views;
 		}
 
-		if ( ! count( get_option( 'hidden-posts' ) ) ) {
+		if ( ! count( get_option( self::META_KEY, array() ) ) ) {
 			return $views;
 		}
 
 		global $wp_query;
 
 		$query           = array(
-			'post__in' => get_option( 'hidden-posts' ),
+			'post__in' => get_option( self::META_KEY, array() )
 		);
 		$result          = new WP_Query( $query );
 		$class           = ( isset( $_GET['show_hidden'] ) && '1' === $_GET['show_hidden'] ) ? 'class="current"' : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -194,7 +194,7 @@ class Hidden_Posts {
 			return $views;
 		}
 
-		if ( isset( $_GET['post_type'] ) && 'post' !== $_GET['post_type'] ) { // phpcs:ignore
+		if ( isset( $_GET['post_type'] ) && 'post' !== $_GET['post_type'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return $views;
 		}
 
@@ -208,7 +208,7 @@ class Hidden_Posts {
 			'post__in' => get_option( 'hidden-posts' ),
 		);
 		$result          = new WP_Query( $query );
-		$class           = ( isset( $_GET['show_hidden'] ) && '1' === $_GET['show_hidden'] ) ? ' class="current"' : ''; // phpcs:ignore
+		$class           = ( isset( $_GET['show_hidden'] ) && '1' === $_GET['show_hidden'] ) ? 'class="current"' : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$views['hidden'] = sprintf(
 			'<a href="%s"' . $class . '>%s <span class="count">(%d)</span></a>',
 			admin_url( 'edit.php?post_type=post&show_hidden=1' ),
@@ -216,8 +216,8 @@ class Hidden_Posts {
 			$result->found_posts
 		);
 
-		if ( isset( $_GET['show_hidden'] ) && '1' === $_GET['show_hidden'] ) { // phpcs:ignore
-			$wp_query = $result; // phpcs:ignore
+		if ( isset( $_GET['show_hidden'] ) && '1' === $_GET['show_hidden'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$wp_query = $result; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 
 		return $views;


### PR DESCRIPTION
Fixes #26 

**Change**

Add filter to the WP Admin post page to allow users to show hidden posts only.

**Steps to test**

1. Check out this plugin
2. Go to `/wp-admin/edit.php`
3. Create at least one hidden post
4. Look up `/wp-admin/edit.php` again

<table>
<tr>
<td>Before:
<br><br>

![#26-before](https://user-images.githubusercontent.com/3323310/111898849-0d9d4600-8a5b-11eb-8997-4e109072c88e.png)
</td>
<td>After:
<br><br>

![#26-after](https://user-images.githubusercontent.com/3323310/111898850-0fffa000-8a5b-11eb-954c-a5c28524739e.png)
</td>
</tr>
</table> 

**Note**

- This PR depends on PR ~#27~ #31 .
- In lines 197, 211 & 219, I used `//phpcs:ignore` to suppress the warning regarding a missing nonce, which is not needed in this case.
- In line 220, I used `// phpcs:ignore` to suppress an error regarding overwriting the `$wp_query` object, which is needed in this case.