### PR TITLE
Resolve phpcs errors of bootstrap.php file

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,21 +1,28 @@
 <?php
+/**
+ * PHPUnit bootstrap file
+ *
+ * @package Hidden_Posts
+ */
 
-$_tests_dir = getenv( 'WP_TESTS_DIR' );
-if ( ! $_tests_dir ) {
-	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+$hidden_posts_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $hidden_posts_tests_dir ) {
+	$hidden_posts_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
-if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
-	echo "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+if ( ! file_exists( $hidden_posts_tests_dir . '/includes/functions.php' ) ) {
+	echo "Could not find $hidden_posts_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	exit( 1 );
 }
 
-require_once $_tests_dir . '/includes/functions.php';
+require_once $hidden_posts_tests_dir . '/includes/functions.php';
 
-function _manually_load_plugin() {
+/**
+ * Manually load the plugin file.
+ */
+function hidden_posts_manually_load_plugin() {
 	require dirname( __FILE__ ) . '/../hidden-posts.php';
 }
-tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+tests_add_filter( 'muplugins_loaded', 'hidden_posts_manually_load_plugin' );
 
-require $_tests_dir . '/includes/bootstrap.php';
-
-
+require $hidden_posts_tests_dir . '/includes/bootstrap.php';


### PR DESCRIPTION
Fixes #15 

**Note**

Resolve phpcs errors of bootstrap.php file

**Steps to test**

1. Check out this plugin
2. Run `composer i` to install all dependencies
3. Run `composer cs` to check the code against PHP_CodeSniffer
4. See the errors regarding https://github.com/Automattic/hidden-posts/blob/trunk/tests/bootstrap.php
5. Check out this PR
6. Run `composer cs` again
7. See that no more errors appear

**Before**

```
composer cs
> @php ./vendor/bin/phpcs
E. 2 / 2 (100%)



FILE: tests/bootstrap.php
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 5 ERRORS AFFECTING 4 LINES
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  1 | ERROR | Missing file doc comment (Squiz.Commenting.FileComment.Missing)
  3 | ERROR | Global variables defined by a theme/plugin should start with the theme/plugin prefix. Found: "$_tests_dir".
    |       | (WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound)
  5 | ERROR | Global variables defined by a theme/plugin should start with the theme/plugin prefix. Found: "$_tests_dir".
    |       | (WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound)
 14 | ERROR | Functions declared in the global namespace by a theme/plugin should start with the theme/plugin prefix. Found: "_manually_load_plugin".
    |       | (WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound)
 14 | ERROR | Missing doc comment for function _manually_load_plugin() (Squiz.Commenting.FunctionComment.Missing)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Time: 511ms; Memory: 14MB

Script @php ./vendor/bin/phpcs handling the cs event returned with error code 1
```

**After**

```
composer cs         
> @php ./vendor/bin/phpcs
.. 2 / 2 (100%)


Time: 499ms; Memory: 14MB
```