### PR TITLE
Trigger hooks outside constructor

### DIFF
--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -87,7 +87,7 @@ class Hidden_Posts {
 	 *
 	 * @return array Array of Post IDs.
 	 */
-	public function get_posts() {
+	public static function get_posts() {
 		return array_filter( array_map( 'absint', get_option( self::OPTION_KEY, array() ) ) );
 	}
 
@@ -262,6 +262,5 @@ $hidden_posts->run();
  * @return array Array of Post IDs.
  */
 function vip_get_hidden_posts() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
-	$hidden_posts = new Hidden_Posts();
-	return $hidden_posts->get_posts();
+	return Hidden_Posts::get_posts();
 }

--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -29,7 +29,7 @@ class Hidden_Posts {
 	/**
 	 * Get hooked in!
 	 */
-	public function __construct() {
+	public function run() {
 		add_action( 'save_post', array( $this, 'save_meta' ) );
 		add_action( 'add_meta_boxes', array( $this, 'add_metabox' ) );
 		add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
@@ -87,7 +87,7 @@ class Hidden_Posts {
 	 *
 	 * @return array Array of Post IDs.
 	 */
-	public static function get_posts() {
+	public function get_posts() {
 		return array_filter( array_map( 'absint', get_option( self::OPTION_KEY, array() ) ) );
 	}
 
@@ -100,7 +100,7 @@ class Hidden_Posts {
 	 *
 	 * @param int $id Post ID.
 	 */
-	public static function add_post( $id ) {
+	public function add_post( $id ) {
 		$posts = self::get_posts();
 
 		if ( in_array( $id, $posts ) ) {
@@ -253,7 +253,8 @@ class Hidden_Posts {
 
 }
 
-new Hidden_Posts();
+$hidden_posts = new Hidden_Posts();
+$hidden_posts->run();
 
 /**
  * Helper function to get hidden posts.
@@ -261,5 +262,5 @@ new Hidden_Posts();
  * @return array Array of Post IDs.
  */
 function vip_get_hidden_posts() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
-	return Hidden_Posts::get_posts();
+	return $hidden_posts->get_posts();
 }

--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -262,5 +262,6 @@ $hidden_posts->run();
  * @return array Array of Post IDs.
  */
 function vip_get_hidden_posts() { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+	$hidden_posts = new Hidden_Posts();
 	return $hidden_posts->get_posts();
 }


### PR DESCRIPTION
Fixes #30 

**Notes**

On https://carlalexander.ca/designing-class-wordpress-hooks/, Carl Alexander wrote:

> The job of the constructor is to create the initial state of a new object. I think everyone can agree with that (I hope!). Things break down when determining the limits of that job.

> The constructor is only in charge of the initial INTERNAL state of a new object. That’s where the issue with putting hooks in the __construct method comes from.

> WordPress hooks have nothing to do with setting up an initial internal state of an object. Hooking into WordPress is a separate job (from an object-oriented design perspective). It’s better to handle it as such. Or at least, it’s better practice for you.

Looking at this plugin, I noticed that we're calling all hooks within the constructor:

https://github.com/Automattic/hidden-posts/blob/9ecaf7aeaa076364bc042b46f53f480d6015cd18/hidden-posts.php#L29-L40

This PR aims to trigger all hooks outside the constructor, which eliminates unwanted side effects when implementing and running unit tests. In https://github.com/Parsely/wp-parsely/issues/280, @GaryJones did the same improvement for the Parsely plugin.

**Steps to test**

1. Check out this PR.
2. Go to /wp-admin/edit.php?post_type=post
3. Mark one of the posts as hidden
4. Go to /
5. Search for the post that had been marked as hidden
6. Ensure that the hidden post is not visible in the search
7. Go to /wp-admin/edit.php?post_type=post
8. Mark the hidden post as visible
9. Go to /
10. Search for the same post again
11. Ensure that the post is visible now