### PR TITLE
Remove hidden posts from next/previous links

### DIFF
--- a/hidden-posts.php
+++ b/hidden-posts.php
@@ -37,6 +37,8 @@ class Hidden_Posts {
 		add_action( 'manage_posts_custom_column', array( $this, 'custom_column_data' ), 10, 2 );
 		add_action( 'admin_head', array( $this, 'custom_column_style' ) );
 		add_filter( 'views_edit-post', array( $this, 'custom_column_filter' ) );
+		add_filter( 'get_previous_post_where', array( $this, 'render_pagination' ) );
+		add_filter( 'get_next_post_where', array( $this, 'render_pagination' ) );
 	}
 
 	/**
@@ -249,6 +251,29 @@ class Hidden_Posts {
 			checked( $checked, true, false ),
 			esc_html( apply_filters( 'hidden_posts_checkbox_text', 'Hide post' ) )
 		);
+	}
+
+	/**
+	 * Render the pagination without all hidden posts.
+	 * 
+	 * @param string $where The original SQL query for the pagination.
+	 * @return string The updated SQL query for the pagination.
+	 */
+	public function render_pagination( $where ) {
+		$posts = implode( ',', self::get_posts() );
+
+		// Return the original SQL query, if no hidden posts are available.
+		if ( '' === $posts ) {
+			return $where;
+		}
+
+		// Return the original SQL query, if filter show_hidden_posts_in_pagination is set to true.
+		if ( apply_filters( 'show_hidden_posts_in_pagination', false ) ) {
+			return $where;
+		}
+
+		// Return the updated SQL query.
+		return $where . " AND p.ID NOT IN ( $posts )";
 	}
 
 }


### PR DESCRIPTION
Fixes #2 

**Note**

Remove hidden posts from next/previous links.

**Steps to test**

1. Check out this PR
2. Head over to `/wp-admin/edit.php?post_type=post`
3. Create the posts `#2-1-visible`, `#2-2-hidden` and `#2-3-visible`
4. Ensure that `#2-2-hidden` is not marked as hidden for now
5. Head over to `/2-1-visible/`
6. Ensure that all posts appear in the next/previous links
7. Head over to `/wp-admin/edit.php?post_type=post`
8. Mark the post `#2-2-hidden` as hidden
9. Head over to `/2-1-visible/`
10. Ensure that only visible posts appear in the next/previous links
11. Add filter `add_filter( 'show_hidden_posts_in_pagination', '__return_true' );`
12. Ensure that both visible and hidden posts appear in the next/previous links

<table>
<tr>
<td>Before:
<br><br>

![#2-before](https://user-images.githubusercontent.com/3323310/124893346-eef79680-dfda-11eb-8187-907574012db4.png)
</td>
<td>After:
<br><br>

![#2-after](https://user-images.githubusercontent.com/3323310/124893354-f159f080-dfda-11eb-9066-cdce832bcd36.png)
</td>
</tr>
</table>