### PR TITLE
Only trigger GitHub Actions on push and manually, but not on pull requests

### DIFF
--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -6,7 +6,6 @@ on:
   push:
     paths-ignore:
       - "**.md"
-  pull_request:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -6,7 +6,6 @@ on:
   push:
     paths-ignore:
       - "**.md"
-  pull_request:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 


### PR DESCRIPTION
Fixes #38 

**Note**

Only trigger GitHub Actions on push and manually, but not on pull requests.

**Steps to test**

Look up the GitHub Actions of this PR, to ensure that the GitHub Actions only run once:

<img width="939" alt="Screenshot 2021-07-08 at 12 25 24" src="https://user-images.githubusercontent.com/3323310/124906655-95499900-dfe7-11eb-9a07-698cb9552a7b.png">
